### PR TITLE
fix: derive article ID from item.Link instead of item.GUID

### DIFF
--- a/internal/feed/fetcher.go
+++ b/internal/feed/fetcher.go
@@ -39,7 +39,7 @@ func (r GoFeed) Fetch(ctx context.Context, url string) (event.Feed, error) {
 	feedID := hash.Hash(feed.FeedLink)
 	articles := make([]event.Article, len(feed.Items))
 	for i, item := range feed.Items {
-		articleID := hash.Hash(item.GUID)
+		articleID := hash.Hash(item.Link)
 		article := event.Article{
 			ArticleID:   articleID,
 			FeedID:      feedID,


### PR DESCRIPTION
GUID is optional in RSS and can be empty, causing hash collisions when multiple articles hash to the same ID. item.Link is the canonical article URL and is more reliably unique.