### PR TITLE
fix: correctly assert no blank lines in TestParser_Parse_BlankLinesStripped

### DIFF
--- a/pkg/markdown/parser_test.go
+++ b/pkg/markdown/parser_test.go
@@ -1,6 +1,7 @@
 package markdown_test
 
 import (
+	"strings"
 	"testing"
 
 	"rss-feed/pkg/markdown"
@@ -111,8 +112,8 @@ func TestParser_Parse_BlankLinesStripped(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	for _, line := range []string{got} {
-		if line == "" {
+	for _, line := range strings.Split(got, "\n") {
+		if strings.TrimSpace(line) == "" {
 			t.Errorf("expected no blank lines in output, got %q", got)
 		}
 	}


### PR DESCRIPTION
Closes #18

## Summary

The previous assertion iterated over `[]string{got}` — a single-element slice containing the whole output — so it only verified the entire string wasn't empty. Blank lines within the output were never caught.

Fixed by splitting `got` by `\n` and checking each line individually with `strings.TrimSpace`.

## Test plan

- [ ] `go test ./pkg/markdown/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)