### PR TITLE
fix: log errors in FindArticles handler

### DIFF
--- a/handler/find.go
+++ b/handler/find.go
@@ -6,6 +6,7 @@ import (
 	"rss-feed/usecase"
 
 	"github.com/go-chi/render"
+	"github.com/rs/zerolog"
 )
 
 // FindArticles godoc
@@ -27,14 +28,18 @@ func FindArticles(uc *usecase.Find) http.HandlerFunc {
 			return
 		}
 
+		logger := zerolog.Ctx(r.Context())
+
 		articles, err := uc.Execute(r.Context(), term)
 		if err != nil {
+			logger.Error().Err(err).Msg("failed to find articles")
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
 		render.Status(r, http.StatusOK)
 		if err := render.Render(w, r, presenter.NewArticleListResponse(articles)); err != nil {
+			logger.Error().Err(err).Msg("failed to render articles response")
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}


### PR DESCRIPTION
Closes #15

## Summary

Errors from `uc.Execute` and `render.Render` were silently returned as HTTP 500s with no log entry. Added `zerolog.Ctx` logger calls before each error response so failures are visible in the log stream.

## Test plan

- [ ] `go build ./...` passes
- [ ] Trigger a search error and confirm it appears in the logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)