### PR TITLE
fix: guard distanceGroups index access in Chroma query

### DIFF
--- a/internal/database/chroma.go
+++ b/internal/database/chroma.go
@@ -84,7 +84,7 @@ func (c *Chroma) FindArticlesIDsByTerm(ctx context.Context, term string) ([]stri
 	}
 
 	// Chroma returns results in ascending distance order, so we can stop at the first exceeded threshold.
-	hasDistances := len(distanceGroups) > 0
+	hasDistances := len(distanceGroups) > 0 && len(distanceGroups[0]) == len(idGroups[0])
 	ids := make([]string, 0, len(idGroups[0]))
 	for i, id := range idGroups[0] {
 		if hasDistances && float64(distanceGroups[0][i]) > maxDistance {


### PR DESCRIPTION
Closes #16

## Summary

`hasDistances` previously only checked that `distanceGroups` was non-empty, but `distanceGroups[0][i]` was still accessed without verifying `distanceGroups[0]` had the same length as `idGroups[0]`. If Chroma returned mismatched group dimensions this would panic at runtime.

Fixed by extending the guard to also require length equality:

```go
hasDistances := len(distanceGroups) > 0 && len(distanceGroups[0]) == len(idGroups[0])
```

## Test plan

- [ ] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)