### PR TITLE
fix: include feed name in event.Article so Chroma metadata is populated

### DIFF
--- a/internal/feed/fetcher.go
+++ b/internal/feed/fetcher.go
@@ -43,6 +43,7 @@ func (r GoFeed) Fetch(ctx context.Context, url string) (event.Feed, error) {
 		article := event.Article{
 			ArticleID:   articleID,
 			FeedID:      feedID,
+			FeedName:    feed.Title,
 			Title:       item.Title,
 			Description: item.Description,
 			Content:     item.Content,

--- a/pkg/event/rss.go
+++ b/pkg/event/rss.go
@@ -23,6 +23,7 @@ type (
 	Article struct {
 		ArticleID   string    `json:"article_id"`
 		FeedID      string    `json:"feed_id"`
+		FeedName    string    `json:"feed_name"`
 		Title       string    `json:"title"`
 		Description string    `json:"description"`
 		Content     string    `json:"content"`
@@ -42,6 +43,10 @@ func (a Article) ToDomain() rss.Article {
 		Categories:  a.Categories,
 		URL:         a.URL,
 		PublishedAt: a.PublishedAt,
+		Feed: rss.Feed{
+			ID:   a.FeedID,
+			Name: a.FeedName,
+		},
 	}
 }
 

--- a/pkg/event/rss_test.go
+++ b/pkg/event/rss_test.go
@@ -12,6 +12,7 @@ func TestArticle_ToDomain(t *testing.T) {
 	a := event.Article{
 		ArticleID:   "article-1",
 		FeedID:      "feed-abc",
+		FeedName:    "Test Blog",
 		Title:       "First Post",
 		Description: "A short description",
 		Content:     "Full content here",
@@ -47,6 +48,12 @@ func TestArticle_ToDomain(t *testing.T) {
 	}
 	if !got.PublishedAt.Equal(publishedAt) {
 		t.Errorf("expected PublishedAt %v, got %v", publishedAt, got.PublishedAt)
+	}
+	if got.Feed.ID != a.FeedID {
+		t.Errorf("expected Feed.ID %q, got %q", a.FeedID, got.Feed.ID)
+	}
+	if got.Feed.Name != a.FeedName {
+		t.Errorf("expected Feed.Name %q, got %q", a.FeedName, got.Feed.Name)
 	}
 }
 


### PR DESCRIPTION
Closes #22

## Summary

`Chroma.CreateArticle` stores `article.Feed.Name` as metadata, but `event.Article.ToDomain()` only carried `FeedID` — never `FeedName`. This meant `rss.Article.Feed.Name` was always an empty string in Chroma.

**Changes:**
- Added `FeedName string` field to `event.Article`
- Set it from `feed.Title` in the fetcher when constructing article events
- Populated `rss.Article.Feed` (ID + Name) in `Article.ToDomain()`

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./pkg/event/...` passes
- [ ] Index an article and verify the `feed` attribute in Chroma is non-empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)